### PR TITLE
Add Dockerfile and instructions for running on workstation 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:bionic
+LABEL author=yinglilu@gmail.com
+LABEL maintainer=isolove@uwo.ca
+LABEL version=0.0.1i
+
+
+RUN apt-get update && apt-get install -y    git \
+                                            curl \
+                                            zip \
+                                            wget \
+                                            default-jre \
+                                            python-pip \
+                                            sudo
+
+# Install the app
+COPY . /opt/cfmm2tar
+
+# Install dcm4che
+RUN bash /opt/cfmm2tar/install_dcm4che_ubuntu.sh /opt
+
+
+
+#For retrieving physio dicom files. without this line, all the physio series will not be retrieved with getscu
+RUN echo '1.3.12.2.1107.5.9.1:ImplicitVRLittleEndian;ExplicitVRLittleEndian' >>/opt/dcm4che/etc/getscu/store-tcs.properties
+
+#allow the getscu client to download CFMM's 9.4T data.
+RUN echo 'EnhancedMRImageStorage:ImplicitVRLittleEndian;ExplicitVRLittleEndian'>>/opt/dcm4che/etc/getscu/store-tcs.properties
+
+# Install DicomRaw
+WORKDIR /opt
+RUN git clone https://gitlab.com/cfmm/dicomraw
+WORKDIR dicomraw
+RUN sudo pip install -r requirements.txt
+
+ENV PATH=/opt/dcm4che/bin:/opt/cfmm2tar:/opt/dicomraw/bin:${PATH}
+ENV _JAVA_OPTIONS="-Xmx2048m"
+
+ENTRYPOINT ["/opt/cfmm2tar/cfmm2tar"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# cfmm2tar
+
+Download a tarballed DICOM dataset from the CFMM DICOM server
+
+## Docker image
+
+1. Install Docker
+
+2. Clone this repo and build the image:
+
+```bash
+git clone https://github.com/khanlab/cfmm2tar
+cd cfmm2tar
+docker build -t cfmm2tar .
+```
+
+3. Run the containerized `cfmm2tar`:
+
+```bash
+OUTPUT_DIR=/path/to/dir
+mkdir ${OUTPUT_DIR}
+docker run -i -t --rm --volume ${OUTPUT_DIR}:/data cfmm2tar
+```
+
+This will display help on using `cfmm2tar`
+
+Search and download a specific dataset, e.g.
+
+```bash
+docker run -i -t --rm --volume ${OUTPUT_DIR}:/data cfmm2tar -p 'Everling^Marmoset' -d '20180803' /data
+```
+
+(You will be asked for your UWO username and password, and will only be able to find and download datasets to which you have read permissions).

--- a/install_dcm4che_ubuntu.sh
+++ b/install_dcm4che_ubuntu.sh
@@ -60,6 +60,8 @@ do
   keytool -noprompt -importcert -trustcacerts -alias letsencrypt -file <(wget -O - -o /dev/null ${LETSENCRYPT_CA_URL}) -keystore $f -storepass secret
 done
 
+ln -s ${D_DIR} /opt/dcm4che
+
 #use this command to test.
 #by StudyInstanceUID
 #getscu --bind DEFAULT --connect CFMM-Public@dicom.cfmm.robarts.ca:11112 --tls-aes --user YOUR_UWO_USERNAME --user-pass YOUR_PASSWORD, -m StudyInstanceUID=1.3.12.2.1107.5.2.34.18932.30000017052914152689000000013


### PR DESCRIPTION
I thought I'd add a `Dockerfile` to be able to easily run `cfmm2tar` on workstations - several people have asked me for an easy-to-use method for manually downloading DICOM datasets, and `cfmm2tar` already does that.

It's not perfect but it gets the job done (see `README.md`).