### PR TITLE
Update DICOM server CA URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 LABEL author=yinglilu@gmail.com
 LABEL maintainer=isolove@uwo.ca
 LABEL version=0.0.2

--- a/install_dcm4che_ubuntu.sh
+++ b/install_dcm4che_ubuntu.sh
@@ -54,10 +54,10 @@ fi
 #fi
 
 # this is a bash script
-LETSENCRYPT_CA_URL=https://letsencrypt.org/certs/lets-encrypt-r3.pem
+ISSUER_CA_URL=https://pki.uwo.ca/sectigo/certificates/SectigoRSAOrganizationValidationSecureServerCA-int.pem
 for f in $(find ${D_DIR}/etc -name cacerts.jks)
 do
-  keytool -noprompt -importcert -trustcacerts -alias letsencrypt -file <(wget -O - -o /dev/null ${LETSENCRYPT_CA_URL}) -keystore $f -storepass secret
+  keytool -noprompt -importcert -trustcacerts -alias issuer -file <(wget -O - -o /dev/null ${ISSUER_CA_URL}) -keystore $f -storepass secret
 done
 
 ln -s ${D_DIR} /opt/dcm4che


### PR DESCRIPTION
DICOM server certificate is changed, so I updated the URL for the signing CA that's now being used. Otherwise `cfmm2tar` fails with a certificate validation error: `unable to find valid certification path to requested target`.

Note: had to use Ubuntu Bionic instead of Xenial for the Docker build to work (Xenial is old and the pip/setuptools apt packages now seem to be broken).