### PR TITLE
Add method to find unique PIs

### DIFF
--- a/Dcm4cheUtils.py
+++ b/Dcm4cheUtils.py
@@ -155,6 +155,27 @@ class Dcm4cheUtils():
 
         return StudyInstanceUID_list
 
+    def get_all_pi_names(self):
+        """Find all PIs the user has access to (by StudyDescription).
+
+        Specifically, find all StudyDescriptions, take the portion before
+        the caret, and return each unique value."""
+        cmd = self._findscu_str +\
+            " -r StudyDescription " +\
+            "| grep StudyDescription " +\
+            "| cut -d[ -f 2 | cut -d] -f 1 " +\
+            "| grep . " +\
+            "| cut -d^ -f 1 " +\
+            "| sort -u"
+
+        out, err, _ = self._get_stdout_stderr_returncode(cmd)
+
+        if err and err != "Picked up _JAVA_OPTIONS: -Xmx2048m\n":
+            self.logger.error(err)
+
+        return out.splitlines()
+
+
     def retrieve_by_StudyInstanceUID(self, StudyInstanceUID, output_dir, timeout_sec=1800):
         '''
         retrive dicom file by key StudyInstanceUID. If PACS not ready for retrieving(e.g. console still sending data to PACS), it will keep checking until time out (30 mins)

--- a/test/test_Dcm4cheUtils.py
+++ b/test/test_Dcm4cheUtils.py
@@ -34,6 +34,10 @@ logging.info('------testing------ get_StudyInstanceUID_by_matching_key')
 r = cfmm_dcm4che_utils.get_StudyInstanceUID_by_matching_key(MATCHING_KEY)
 logging.info(r)
 
+logging.info('------testing------ get_all_pi_names')
+r = cfmm_dcm4che_utils.get_all_pi_names()
+logging.info(r)
+
 logging.info('------testing------ ready_for_retrieve')
 r = cfmm_dcm4che_utils._ready_for_retrieve(MATCHING_KEY)
 logging.info(r)


### PR DESCRIPTION
For the new autobids portal, we'd like to prepopulate the request form with a list of PIs. This method should facilitate that process by allowing a user to find every unique PI associated with any studies they have access to (by way of the first portion of those studies' StudyDescriptions).