### PR TITLE
Update to allow connections to new CFMM DICOM server

### DIFF
--- a/Dcm4cheUtils.py
+++ b/Dcm4cheUtils.py
@@ -25,7 +25,7 @@ class Dcm4cheUtils():
     dcm4che utils
     '''
 
-    def __init__(self, connect, username, password, dcm4che_path=''):
+    def __init__(self, connect, username, password, dcm4che_path='', other_options=''):
         self.logger = logging.getLogger(__name__)
         self.connect = connect
         self.username = username
@@ -37,15 +37,17 @@ class Dcm4cheUtils():
             ' --bind  DEFAULT' +\
             ' --connect {}'.format(self.connect) +\
             ' --accept-timeout 10000 ' +\
-            ''' --tls-aes --user {} '''.format(pipes.quote(self.username)) +\
+            ' {} '.format(other_options) +\
+            ''' --user {} '''.format(pipes.quote(self.username)) +\
             ''' --user-pass {} '''.format(pipes.quote(self.password))
 
         self._getscu_str = \
             '''{} getscu'''.format(self.dcm4che_path) +\
             ' --bind  DEFAULT ' +\
             ' --connect {} '.format(self.connect) +\
-            ' --accept-timeout 10000 ' +\
-            ''' --tls-aes --user {} '''.format(pipes.quote(self.username)) +\
+            ' --accept-timeout 10000 ' + \
+            ' {} '.format(other_options) + \
+            ''' --user {} '''.format(pipes.quote(self.username)) +\
             ''' --user-pass {} '''.format(pipes.quote(self.password))
 
     def _get_stdout_stderr_returncode(self, cmd):

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,7 @@
 FROM ubuntu:bionic
 LABEL author=yinglilu@gmail.com
 LABEL maintainer=isolove@uwo.ca
-LABEL version=0.0.2
-
-# Copy files from repo
-COPY *.py /apps/cfmm2tar/
-COPY cfmm2tar /apps/cfmm2tar/
-COPY *.sh /src/
+LABEL version=0.0.3
 
 #needed for keytool
 RUN if [ ! -e /dev/fd ]; then ln -s /proc/self/fd /dev/fd; fi
@@ -25,30 +20,44 @@ RUN apt-get update && apt-get install -y --no-install-recommends apt-utils \
     openssh-client
 RUN pip install --upgrade pip && pip install --upgrade setuptools
 
+# dcm4che requires JRE
+# enable TLSv1.1 for dcm4chee v2
+RUN apt-get install -y default-jre && sed -i 's/TLSv1.1, //g' /etc/java-11-openjdk/security/java.security
+
+# Copy files from repo
+COPY *.py /apps/cfmm2tar/
+
 #for some unknown reason, need change the mode:
 RUN chmod a+x /apps/cfmm2tar/*.py
-
 
 #dicomunwrap, will install pydicom
 RUN cd /apps && git clone https://gitlab.com/cfmm/DicomRaw && cd DicomRaw && pip install -r requirements.txt
 
-
-#needed when install dcm4che
-RUN apt-get install -y default-jre
+COPY *.sh /src/
 
 #install dcm4che
+ENV DCM4CHE_VERSION=5.24.1
 RUN cd /src && bash install_dcm4che_ubuntu.sh /opt
 
-
 #For retrieving physio dicom files. without this line, all the physio series will not be retrieved with getscu
-RUN echo '1.3.12.2.1107.5.9.1:ImplicitVRLittleEndian;ExplicitVRLittleEndian' >>/opt/dcm4che-3.3.8/etc/getscu/store-tcs.properties
+RUN echo '1.3.12.2.1107.5.9.1:ImplicitVRLittleEndian;ExplicitVRLittleEndian' >>/opt/dcm4che/etc/getscu/store-tcs.properties
 
 #allow the getscu client to download CFMM's 9.4T data.
-RUN echo 'EnhancedMRImageStorage:ImplicitVRLittleEndian;ExplicitVRLittleEndian'>>/opt/dcm4che-3.3.8/etc/getscu/store-tcs.properties
+RUN echo 'EnhancedMRImageStorage:ImplicitVRLittleEndian;ExplicitVRLittleEndian'>>/opt/dcm4che/etc/getscu/store-tcs.properties
+
+COPY cfmm2tar /apps/cfmm2tar/
 
 # env vars:
-ENV PATH=/apps/DicomRaw/bin:/opt/dcm4che-3.3.8/bin:/apps/cfmm2tar:$PATH
+ENV PATH=/apps/DicomRaw/bin:/opt/dcm4che/bin:/apps/cfmm2tar:$PATH
 ENV _JAVA_OPTIONS="-Xmx2048m"
+
+# dcm4chee v2 server
+#ENV DICOM_CONNECTION=CFMM-Public@dicom.cfmm.uwo.ca:11112
+#ENV OTHER_OPTIONS='--tls11 --tls-cipher=TLS_RSA_WITH_AES_128_CBC_SHA'
+
+# dcm4chee v5 server
+ENV DICOM_CONNECTION=CFMM@dicom.cfmm.uwo.ca:11112
+ENV OTHER_OPTIONS='--tls-aes'
 
 
 ENTRYPOINT ["/apps/cfmm2tar/cfmm2tar"]

--- a/cfmm2tar
+++ b/cfmm2tar
@@ -29,6 +29,7 @@ function usage {
   echo "        -U 'path/to/downloaded_uid_list[default:no]'"
   echo "        -c 'path/to/uwo_credentials[default:~/.uwo_credentials]'"
   echo "        -t 'path/to/intermediate_dicoms_dir[default:<output folder>/cfmm2tar_intermediate_dicoms'"
+  echo "        -s 'AETITLE@hostname:11112'"
   echo "                       "
   echo "    Search Options:  "
   echo "        -d 'Date'"
@@ -60,14 +61,16 @@ DOWNLOADED_UID_LIST=
 UWO_CREDNTIALS=~/.uwo_credentials
 DICOMS_DIR=
 
-while getopts "d:n:p:U:c:t:" options; do
+while getopts "d:n:p:U:c:t:s:x:" options; do
  case $options in
     d ) DATE_SEARCH=\'$OPTARG\';;
     n ) NAME_SEARCH=\'$OPTARG\';;
     p ) STUDY_SEARCH=\'$OPTARG\';;
     U ) DOWNLOADED_UID_LIST=$OPTARG;;
     c ) UWO_CREDNTIALS=$OPTARG;;
+    s ) DICOM_CONNECTION=$OPTARG;;
     t ) DICOMS_DIR=$OPTARG;;
+    x ) OTHER_OPTIONS="${OPTARG}";;
     * ) usage
 	exit 1;;
  esac
@@ -101,7 +104,6 @@ if [ ! -f $DOWNLOADED_UID_LIST ]; then
 fi
 
 KEEP_SORTED_DICOM='False'
-CONNECT='CFMM-Public@dicom2.cfmm.robarts.ca:11122'
 
 OUTPUT_DIR=$1
 #retrieve dicoms to this folder
@@ -116,13 +118,14 @@ mkdir -p $OUTPUT_DIR $DICOMS_DIR
 python $execpath/retrieve_cfmm_tar.py \
 ${UWO_USERNAME} \
 ${UWO_PASSWORD} \
-${CONNECT} \
+${DICOM_CONNECTION} \
 ${STUDY_SEARCH} \
 ${DICOMS_DIR} \
 ${KEEP_SORTED_DICOM} \
 ${OUTPUT_DIR} \
 ${DATE_SEARCH} \
 ${NAME_SEARCH} \
+"${OTHER_OPTIONS}" \
 ${DOWNLOADED_UID_LIST}
 
 #clean-up after ourselves

--- a/cfmm2tar
+++ b/cfmm2tar
@@ -101,7 +101,7 @@ if [ ! -f $DOWNLOADED_UID_LIST ]; then
 fi
 
 KEEP_SORTED_DICOM='False'
-CONNECT='CFMM-Public@dicom.cfmm.robarts.ca:11112'
+CONNECT='CFMM-Public@dicom2.cfmm.robarts.ca:11112'
 
 OUTPUT_DIR=$1
 #retrieve dicoms to this folder

--- a/cfmm2tar
+++ b/cfmm2tar
@@ -101,7 +101,7 @@ if [ ! -f $DOWNLOADED_UID_LIST ]; then
 fi
 
 KEEP_SORTED_DICOM='False'
-CONNECT='CFMM-Public@dicom2.cfmm.robarts.ca:11112'
+CONNECT='CFMM-Public@dicom2.cfmm.robarts.ca:11122'
 
 OUTPUT_DIR=$1
 #retrieve dicoms to this folder

--- a/install_dcm4che_ubuntu.sh
+++ b/install_dcm4che_ubuntu.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -x
+
 
 if [ "$#" -lt 1 ];then
 	echo "Usage: $0 <install folder (absolute path)>"
@@ -12,15 +14,14 @@ echo -n "installing dcm4che..." #-n without newline
 DEST=$1
 mkdir -p $DEST
 
-VERSION=dcm4che-3.3.8
-D_DIR=$DEST/$VERSION
+D_DIR=$DEST/dcm4che-$DCM4CHE_VERSION
 if [ -d $D_DIR ]; then
 	rm -rf $D_DIR
 fi
 
-wget https://iweb.dl.sourceforge.net/project/dcm4che/dcm4che3/3.3.8/$VERSION-bin.zip
-unzip $VERSION-bin.zip -d $DEST
-rm $VERSION-bin.zip
+wget https://iweb.dl.sourceforge.net/project/dcm4che/dcm4che3/$DCM4CHE_VERSION/dcm4che-$DCM4CHE_VERSION-bin.zip
+unzip dcm4che-$DCM4CHE_VERSION-bin.zip -d $DEST
+rm dcm4che-$DCM4CHE_VERSION-bin.zip
 
 
 if [ -e $HOME/.profile ]; then #ubuntu
@@ -55,7 +56,7 @@ fi
 
 # this is a bash script
 ISSUER_CA_URL=https://pki.uwo.ca/sectigo/certificates/SectigoRSAOrganizationValidationSecureServerCA-int.pem
-for f in $(find ${D_DIR}/etc -name cacerts.jks)
+for f in $(find ${D_DIR}/etc -name cacerts.jks -or -name cacerts.p12)
 do
   keytool -noprompt -importcert -trustcacerts -alias issuer -file <(wget -O - -o /dev/null ${ISSUER_CA_URL}) -keystore $f -storepass secret
 done

--- a/retrieve_cfmm_tar.py
+++ b/retrieve_cfmm_tar.py
@@ -78,6 +78,7 @@ def main(uwo_username,
          tar_dest_dir,
          study_date,
          patient_name,
+         other_options,
          downloaded_uids_filename,
          dcm4che_path):
     '''
@@ -92,7 +93,7 @@ def main(uwo_username,
 
     # Dcm4cheUtils
     cfmm_dcm4che_utils = Dcm4cheUtils.Dcm4cheUtils(
-        connect, uwo_username, uwo_password, dcm4che_path)
+        connect, uwo_username, uwo_password, dcm4che_path, other_options)
 
     # get all StudyInstanceUIDs
     StudyInstanceUIDs = cfmm_dcm4che_utils.get_StudyInstanceUID_by_matching_key(
@@ -176,6 +177,7 @@ if __name__ == "__main__":
                  tgz_dest_dir \
                  scan_date \
                  patient_name \
+                 other_options \
                  [downloaded_uids_filename] \
                  [dcm4che_path]")
         sys.exit()
@@ -191,13 +193,17 @@ if __name__ == "__main__":
         study_date = sys.argv[8]
         patient_name = sys.argv[9]
         if len(sys.argv) > 10:
-            downloaded_uids_filename = sys.argv[10]
+            other_options = sys.argv[10]
+        else:
+            other_options = ''
+        if len(sys.argv) > 11:
+            downloaded_uids_filename = sys.argv[11]
         else:
             downloaded_uids_filename = ''
 
-        if len(sys.argv) > 11:
+        if len(sys.argv) > 12:
             # use dcm4che singularity/docker container runs on host
-            dcm4che_path = sys.argv[11]
+            dcm4che_path = sys.argv[12]
         else:
             # dcm4che installed on host or singularity container's PATH
             dcm4che_path = ''
@@ -211,5 +217,6 @@ if __name__ == "__main__":
              tgz_dest_dir,
              study_date,
              patient_name,
+             other_options,
              downloaded_uids_filename,
              dcm4che_path)


### PR DESCRIPTION
This version will allow to switch between old (dcm4chee v2) and new (dcm4chee v5) DICOM server. This can be done with Docker ENVs or command-line options.

Old server is reachable at `CFMM-Public@dicom.cfmm.uwo.ca:11112`. TLS options are `--tls11 --tls-cipher=TLS_RSA_WITH_AES_128_CBC_SHA`.

New server is reachable at `CFMM-Public@dicom.cfmm.uwo.ca:11115`. TLS options are `--tls-aes`.

Note that I had to change port of the new server from `11122` to `11115` in order to make the server reachable from Compute Canada.