### PR TITLE
Update dcm4che link

### DIFF
--- a/install_dcm4che_ubuntu.sh
+++ b/install_dcm4che_ubuntu.sh
@@ -19,7 +19,7 @@ if [ -d $D_DIR ]; then
 	rm -rf $D_DIR
 fi
 
-wget https://iweb.dl.sourceforge.net/project/dcm4che/dcm4che3/$DCM4CHE_VERSION/dcm4che-$DCM4CHE_VERSION-bin.zip
+wget https://master.dl.sourceforge.net/project/dcm4che/dcm4che3/${DCM4CHE_VERSION}/dcm4che-${DCM4CHE_VERSION}-bin.zip
 unzip dcm4che-$DCM4CHE_VERSION-bin.zip -d $DEST
 rm dcm4che-$DCM4CHE_VERSION-bin.zip
 


### PR DESCRIPTION
The https://iweb.dl.sourceforge.net download URL for dcm4che appears to have gone down, preventing cfmm2tar from building for me. This just updates the URL to what I get when I download dcm4che from my browser.

The docker image builds for me with this change, but not without it; I haven't done any more testing, though.