### PR TITLE
quick fix had extra line in tsv

### DIFF
--- a/cfmm2tar/dcm4che_utils.py
+++ b/cfmm2tar/dcm4che_utils.py
@@ -315,10 +315,6 @@ class Dcm4cheUtils:
                         elif tag == "00081030":  # StudyDescription
                             current_study["StudyDescription"] = value
 
-                # Don't forget the last study
-                if current_study.get("StudyInstanceUID"):
-                    studies.append(current_study)
-
                 # Fill in missing fields with empty strings
                 for study in studies:
                     for field in ["PatientName", "PatientID", "StudyDate", "StudyDescription"]:


### PR DESCRIPTION
## Pull Request Overview

This PR fixes a bug in the TSV metadata generation by removing duplicate study entries. The change eliminates an extra append operation that was causing the last study to be added twice to the studies list.

- Removes redundant code that was appending the last study a second time
